### PR TITLE
API 수정 - trailing slash, id 

### DIFF
--- a/toy/src/main/kotlin/com/wafflestudio/toy/domain/post/api/PostController.kt
+++ b/toy/src/main/kotlin/com/wafflestudio/toy/domain/post/api/PostController.kt
@@ -13,13 +13,13 @@ import org.springframework.web.bind.annotation.*
 class PostController(
     private val postService: PostService
 ) {
-    @GetMapping("/recent/")
+    @GetMapping("/recent")
     @ResponseStatus(HttpStatus.OK)
     fun getRecentPost(@PageableDefault(size = 30, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable : Pageable): List<PostDto.MainPageResponse> {
         return postService.getRecentPosts(pageable)
     }
 
-    @GetMapping("/trend/")
+    @GetMapping("/trend")
     @ResponseStatus(HttpStatus.OK)
     fun getTrendingPost(@PageableDefault(size = 30, sort = ["trending"], direction = Sort.Direction.DESC) pageable: Pageable,
                         @RequestParam("date", required = false, defaultValue = "7") date: Int

--- a/toy/src/main/kotlin/com/wafflestudio/toy/domain/post/dto/PostDto.kt
+++ b/toy/src/main/kotlin/com/wafflestudio/toy/domain/post/dto/PostDto.kt
@@ -6,6 +6,7 @@ import java.time.LocalDateTime
 
 class PostDto {
     data class MainPageResponse(
+        val id: Long,
         val user: UserDto.SimpleResponse,
         val title: String,
         val thumbnail: String, // thumbnail file url
@@ -15,6 +16,7 @@ class PostDto {
         val comments: Int      // num of comments
     ) {
         constructor(post: Post) : this(
+            id = post.id,
             user = UserDto.SimpleResponse(post.user),
             title = post.title,
             thumbnail = post.thumbnail,

--- a/toy/src/main/kotlin/com/wafflestudio/toy/domain/user/dto/UserDto.kt
+++ b/toy/src/main/kotlin/com/wafflestudio/toy/domain/user/dto/UserDto.kt
@@ -4,10 +4,12 @@ import com.wafflestudio.toy.domain.user.model.User
 
 class UserDto {
     data class SimpleResponse(
+        val id: Long,
         val username: String,
         val image: String
     ) {
         constructor(user: User) : this(
+            id = user.id,
             username = user.username,
             image = user.image
         )

--- a/toy/src/main/kotlin/com/wafflestudio/toy/global/config/SecurityConfig.kt
+++ b/toy/src/main/kotlin/com/wafflestudio/toy/global/config/SecurityConfig.kt
@@ -29,8 +29,8 @@ class SecurityConfig() : WebSecurityConfigurerAdapter() {
             .and()
             .authorizeRequests()
             .antMatchers(HttpMethod.GET, "/ping/").permitAll() // SignUp user
-            .antMatchers(HttpMethod.GET, "/api/v1/post/recent/").permitAll()
-            .antMatchers(HttpMethod.GET, "/api/v1/post/trend/").permitAll()
+            .antMatchers(HttpMethod.GET, "/api/v1/post/recent").permitAll()
+            .antMatchers(HttpMethod.GET, "/api/v1/post/trend").permitAll()
             .anyRequest().authenticated()   // Because signin api doesn't exist yet, so to test permit all request
     }
 


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
이제 post 도메인의 API response에 post와 user의 id가 포함됩니다.
API url에서 trailing slash를 제거했습니다.

Resolves #21

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [ ] 코드의 이해에 필요한 주석을 작성했습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [ ] 기존 및 신규 단위 테스트를 통과했습니다.
- [ ] (필요한 경우) 문서를 적절하게 수정했습니다.
