### PR TITLE
포트 확인 로직 추가

### DIFF
--- a/toy/scripts/deploy/deploy.sh
+++ b/toy/scripts/deploy/deploy.sh
@@ -16,6 +16,18 @@ else
     sleep 5
 fi
 
+PORT_USING_PID=$(lsof -ti tcp:8080)
+
+if [[ -z $PORT_USING_PID ]];
+then
+    echo "[Deploy] : Port available"
+else
+    echo "[Deploy] : Another application is using port"
+    echo "[Deploy] : Stopping application using port"
+    kill -15 $PORT_USING_PID
+    sleep 5
+fi
+
 echo "[Deploy] : Running new application"
 
 nohup java -jar -Dspring.profiles.active=prod ~/deploy/$JAR_NAME > ~/deploy/nohup.out 2>&1 &


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CI / CD
- [ ] 기타 설정

## PR 설명
```deploy.sh``` 파일에 애플리케이션이 사용할 포트를 사용하고 있는 다른 애플리케이션을 종료시키는 코드를 추가했습니다.
이전 애플리케이션이 종료되어야 하는데, 왜 안 되었는지는 모르겠습니다.

Resolves #29

## 체크리스트
- [ ] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [ ] 코드의 이해에 필요한 주석을 작성했습니다.
- [ ] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [ ] 기존 및 신규 단위 테스트를 통과했습니다.
- [ ] (필요한 경우) 문서를 적절하게 수정했습니다.
