### PR TITLE
CORS credential 설정

### DIFF
--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/SignInAuthenticationFilter.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/SignInAuthenticationFilter.kt
@@ -2,8 +2,6 @@ package com.wafflestudio.waflog.global.auth
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.wafflestudio.waflog.global.auth.dto.LoginRequest
-import com.wafflestudio.waflog.global.auth.exception.VerificationTokenNotFoundException
-import com.wafflestudio.waflog.global.auth.repository.VerificationTokenRepository
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
@@ -17,8 +15,7 @@ import javax.servlet.http.HttpServletResponse
 
 class SignInAuthenticationFilter(
     authenticationManager: AuthenticationManager?,
-    private val jwtTokenProvider: JwtTokenProvider,
-    private val verificationTokenRepository: VerificationTokenRepository
+    private val jwtTokenProvider: JwtTokenProvider
 ) : UsernamePasswordAuthenticationFilter(authenticationManager) {
     init {
         setRequiresAuthenticationRequestMatcher(AntPathRequestMatcher("/api/v1/auth/verify/login", "POST"))
@@ -45,10 +42,8 @@ class SignInAuthenticationFilter(
 
     override fun attemptAuthentication(request: HttpServletRequest, response: HttpServletResponse): Authentication {
         val parsedRequest: LoginRequest = parseRequest(request)
-        val token = verificationTokenRepository.findByToken(parsedRequest.token)
-            ?: throw VerificationTokenNotFoundException("잘못된 토큰")
         val authRequest: Authentication =
-            UsernamePasswordAuthenticationToken(token.email, parsedRequest.token)
+            UsernamePasswordAuthenticationToken(parsedRequest.email, parsedRequest.token)
         return authenticationManager.authenticate(authRequest)
     }
 

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/dto/LoginRequest.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/dto/LoginRequest.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.waflog.global.auth.dto
 
 class LoginRequest {
+    val email: String? = null
     val token: String? = null
 }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/model/VerificationTokenPrincipal.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/model/VerificationTokenPrincipal.kt
@@ -1,10 +1,14 @@
 package com.wafflestudio.waflog.global.auth.model
 
+import com.wafflestudio.waflog.domain.user.model.User
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
-class VerificationTokenPrincipal(val verificationToken: VerificationToken) : UserDetails {
+class VerificationTokenPrincipal(
+    val user: User,
+    val verificationToken: VerificationToken
+) : UserDetails {
     override fun getUsername(): String { return verificationToken.email }
 
     override fun getPassword(): String { return verificationToken.token }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/service/VerificationTokenPrincipalDetailService.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/service/VerificationTokenPrincipalDetailService.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.waflog.global.auth.service
 
+import com.wafflestudio.waflog.domain.user.exception.UserNotFoundException
+import com.wafflestudio.waflog.domain.user.repository.UserRepository
 import com.wafflestudio.waflog.global.auth.model.VerificationTokenPrincipal
 import com.wafflestudio.waflog.global.auth.repository.VerificationTokenRepository
 import org.springframework.security.core.userdetails.UserDetails
@@ -8,11 +10,15 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
 
 @Service
-class VerificationTokenPrincipalDetailService(private val verificationTokenRepository: VerificationTokenRepository) :
-    UserDetailsService {
+class VerificationTokenPrincipalDetailService(
+    private val userRepository: UserRepository,
+    private val verificationTokenRepository: VerificationTokenRepository
+) : UserDetailsService {
     override fun loadUserByUsername(s: String): UserDetails {
-        val user = verificationTokenRepository.findByEmail(s)
+        val user = userRepository.findByEmail(s)
+            ?: throw UserNotFoundException("User with email '$s' not found")
+        val token = verificationTokenRepository.findByEmail(s)
             ?: throw UsernameNotFoundException("User with email '$s' not found")
-        return VerificationTokenPrincipal(user)
+        return VerificationTokenPrincipal(user, token)
     }
 }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/SecurityConfig.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/SecurityConfig.kt
@@ -74,15 +74,16 @@ class SecurityConfig(
 
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
-        var corsConfiguration = CorsConfiguration()
-        corsConfiguration.addAllowedOrigin("*")
+        val corsConfiguration = CorsConfiguration()
+        corsConfiguration.allowCredentials = true
+        corsConfiguration.addAllowedOrigin("https://waflog-web.kro.kr")
         corsConfiguration.addAllowedHeader("*")
         corsConfiguration.addAllowedMethod("GET")
         corsConfiguration.addAllowedMethod("POST")
         corsConfiguration.addAllowedMethod("DELETE")
         corsConfiguration.addAllowedMethod("PUT")
         corsConfiguration.addExposedHeader("Authentication")
-        var source = UrlBasedCorsConfigurationSource()
+        val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", corsConfiguration)
         return source
     }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/SecurityConfig.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/SecurityConfig.kt
@@ -4,7 +4,6 @@ import com.wafflestudio.waflog.global.auth.JwtAuthenticationEntryPoint
 import com.wafflestudio.waflog.global.auth.JwtAuthenticationFilter
 import com.wafflestudio.waflog.global.auth.JwtTokenProvider
 import com.wafflestudio.waflog.global.auth.SignInAuthenticationFilter
-import com.wafflestudio.waflog.global.auth.repository.VerificationTokenRepository
 import com.wafflestudio.waflog.global.auth.service.VerificationTokenPrincipalDetailService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -21,7 +20,6 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.CorsUtils
-import org.springframework.web.cors.CorsUtils.isPreFlightRequest
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
@@ -30,9 +28,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 class SecurityConfig(
     private val jwtAuthenticationEntryPoint: JwtAuthenticationEntryPoint,
     private val jwtTokenProvider: JwtTokenProvider,
-    private val verificationTokenRepository: VerificationTokenRepository,
     private val userPrincipalDetailService: VerificationTokenPrincipalDetailService
-
 ) : WebSecurityConfigurerAdapter() {
     override fun configure(auth: AuthenticationManagerBuilder) {
         auth.authenticationProvider(daoAuthenticationProvider())
@@ -60,7 +56,7 @@ class SecurityConfig(
             .and()
             .addFilter(
                 SignInAuthenticationFilter(
-                    authenticationManager(), jwtTokenProvider, verificationTokenRepository
+                    authenticationManager(), jwtTokenProvider
                 )
             )
             .addFilter(JwtAuthenticationFilter(authenticationManager(), jwtTokenProvider))


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
CORS에서 credential을 사용하고, allowed origin을 제한합니다.
```VerificationTokenPrincipal```에 user를 추가하여 ```@CurrentUser``` annotation이 작동하도록 합니다.

Resolves #79

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [ ] 코드의 이해에 필요한 주석을 작성했습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [ ] 기존 및 신규 단위 테스트를 통과했습니다.
- [ ] (필요한 경우) 문서를 적절하게 수정했습니다.
