### PR TITLE
FIX: #118 filtering private post in get prev and next post

### DIFF
--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/post/model/Post.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/post/model/Post.kt
@@ -61,14 +61,12 @@ class Post(
 ) : BaseTimeEntity() {
 
     fun getPrevPost(): Post? {
-        val userPosts: List<Post> = this.user.posts
-        val userNotPrivatePosts: List<Post> = userPosts.filter { p -> !p.private }
+        val userNotPrivatePosts: List<Post> = this.user.posts.filter { p -> !p.private }
         return userNotPrivatePosts.lastOrNull { it.id < this.id }
     }
 
     fun getNextPost(): Post? {
-        val userPosts: List<Post> = this.user.posts
-        val userNotPrivatePosts: List<Post> = userPosts.filter { p -> !p.private }
+        val userNotPrivatePosts: List<Post> = this.user.posts.filter { p -> !p.private }
         return userNotPrivatePosts.firstOrNull { it.id > this.id }
     }
 }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/post/model/Post.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/post/model/Post.kt
@@ -62,11 +62,13 @@ class Post(
 
     fun getPrevPost(): Post? {
         val userPosts: List<Post> = this.user.posts
-        return userPosts.lastOrNull { it.id < this.id }
+        val userNotPrivatePosts: List<Post> = userPosts.filter { p -> !p.private }
+        return userNotPrivatePosts.lastOrNull { it.id < this.id }
     }
 
     fun getNextPost(): Post? {
         val userPosts: List<Post> = this.user.posts
-        return userPosts.firstOrNull { it.id > this.id }
+        val userNotPrivatePosts: List<Post> = userPosts.filter { p -> !p.private }
+        return userNotPrivatePosts.firstOrNull { it.id > this.id }
     }
 }


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
포스트 디테일을 반환할때 다음포스트와 이전포스트에 비공개 게시글이 포함되는 버그 발생하여
다음포스트와 이전포스트를 반환하기 이전에 필터링하여 해결

Resolves #118 

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [ ] 코드의 이해에 필요한 주석을 작성했습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [ ] 기존 및 신규 단위 테스트를 통과했습니다.
- [ ] (필요한 경우) 문서를 적절하게 수정했습니다.
