### PR TITLE
소셜 회원가입 로직 추가

### DIFF
--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/exception/UserIdAlreadyExistException.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/exception/UserIdAlreadyExistException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.waflog.domain.user.exception
+
+import com.wafflestudio.waflog.global.common.exception.ConflictException
+import com.wafflestudio.waflog.global.common.exception.ErrorType
+
+class UserIdAlreadyExistException(detail: String = "") :
+    ConflictException(ErrorType.USER_ID_CONFLICT, detail)

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/repository/UserRepository.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/repository/UserRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long?> {
     fun findByEmail(email: String): User?
+    fun existsByUserId(userId: String): Boolean
 }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/JwtTokenProvider.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/JwtTokenProvider.kt
@@ -5,19 +5,22 @@ import com.wafflestudio.waflog.global.auth.exception.VerificationTokenNotFoundEx
 import com.wafflestudio.waflog.global.auth.model.AuthenticationToken
 import com.wafflestudio.waflog.global.auth.model.VerificationTokenPrincipal
 import com.wafflestudio.waflog.global.auth.repository.VerificationTokenRepository
-import com.wafflestudio.waflog.global.oauth2.repository.OAuth2UserTokenRepository
-import io.jsonwebtoken.*
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.MalformedJwtException
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.SignatureException
+import io.jsonwebtoken.UnsupportedJwtException
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Component
-import java.util.*
+import java.util.Date
 
 @Component
 class JwtTokenProvider(
     private val userRepository: UserRepository,
-    private val verificationTokenRepository: VerificationTokenRepository,
-    private val oAuth2UserTokenRepository: OAuth2UserTokenRepository
+    private val verificationTokenRepository: VerificationTokenRepository
 ) {
     private val logger = LoggerFactory.getLogger(JwtTokenProvider::class.java)
     val tokenPrefix = "Bearer "
@@ -104,7 +107,6 @@ class JwtTokenProvider(
         val email = claims.get("email", String::class.java)
         val currentUser = userRepository.findByEmail(email)
         val currentAuthToken = verificationTokenRepository.findByEmail(email)
-            ?: oAuth2UserTokenRepository.findByEmail(email)
             ?: throw VerificationTokenNotFoundException("$email is not valid email, check token is expired")
         val userPrincipal = VerificationTokenPrincipal(currentUser, currentAuthToken)
         val authorises = userPrincipal.authorities

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/model/SignUpAttempt.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/model/SignUpAttempt.kt
@@ -13,5 +13,7 @@ class SignUpAttempt(
     @field:Email
     val email: String,
 
+    val image: String = "",
+
     var jwt: String
 ) : BaseEntity()

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/service/AuthService.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/service/AuthService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.waflog.global.auth.service
 
 import com.wafflestudio.waflog.domain.user.dto.UserDto
+import com.wafflestudio.waflog.domain.user.exception.UserIdAlreadyExistException
 import com.wafflestudio.waflog.domain.user.model.User
 import com.wafflestudio.waflog.domain.user.repository.UserRepository
 import com.wafflestudio.waflog.global.auth.JwtTokenProvider
@@ -69,6 +70,8 @@ class AuthService(
         val jwtEmail = jwtTokenProvider.getEmailFromJwt(jwt)
         if (attempt.email != jwtEmail)
             throw JWTInvalidException("JWT does not correspond to the email")
+        if (userRepository.existsByUserId(userId))
+            throw UserIdAlreadyExistException("User with this id already exists")
 
         val user = userRepository.save(
             User(

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/service/AuthService.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/auth/service/AuthService.kt
@@ -70,16 +70,17 @@ class AuthService(
         if (attempt.email != jwtEmail)
             throw JWTInvalidException("JWT does not correspond to the email")
 
-        signUpAttemptRepository.deleteById(attempt.id)
         val user = userRepository.save(
             User(
                 email = email,
                 userId = userId,
                 name = name,
+                image = attempt.image,
                 shortIntro = shortIntro,
                 pageTitle = "$userId.log"
             )
         )
+        signUpAttemptRepository.deleteById(attempt.id)
 
         val token = generateVerificationToken(user)
 
@@ -94,7 +95,7 @@ class AuthService(
             it.jwt = jwt
             signUpAttemptRepository.save(it)
         } ?: run {
-            signUpAttemptRepository.save(SignUpAttempt(email, jwt))
+            signUpAttemptRepository.save(SignUpAttempt(email = email, jwt = jwt))
         }
 
         return jwt

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/common/exception/ErrorType.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/common/exception/ErrorType.kt
@@ -23,6 +23,7 @@ enum class ErrorType(
     TOKEN_NOT_FOUND(4006),
 
     CONFLICT(9000),
+    USER_ID_CONFLICT(9011),
 
     SERVER_ERROR(10000)
 }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/PasswordConfig.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/PasswordConfig.kt
@@ -1,0 +1,14 @@
+package com.wafflestudio.waflog.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@Configuration
+class PasswordConfig {
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+}

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/SecurityConfig.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/SecurityConfig.kt
@@ -19,7 +19,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
@@ -35,21 +34,17 @@ class SecurityConfig(
     private val oAuth2SuccessHandler: OAuth2SuccessHandler,
     private val customAuth2UserService: CustomAuth2UserService,
     private val userPrincipalDetailService: VerificationTokenPrincipalDetailService,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val passwordEncoder: PasswordEncoder
 ) : WebSecurityConfigurerAdapter() {
     override fun configure(auth: AuthenticationManagerBuilder) {
         auth.authenticationProvider(daoAuthenticationProvider())
     }
 
     @Bean
-    fun passwordEncoder(): PasswordEncoder {
-        return BCryptPasswordEncoder()
-    }
-
-    @Bean
     fun daoAuthenticationProvider(): DaoAuthenticationProvider {
         val provider = DaoAuthenticationProvider()
-        provider.setPasswordEncoder(passwordEncoder())
+        provider.setPasswordEncoder(passwordEncoder)
         provider.setUserDetailsService(userPrincipalDetailService)
         return provider
     }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/oauth2/OAuth2SuccessHandler.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/oauth2/OAuth2SuccessHandler.kt
@@ -1,12 +1,13 @@
 package com.wafflestudio.waflog.global.oauth2
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.wafflestudio.waflog.domain.user.model.User
 import com.wafflestudio.waflog.domain.user.repository.UserRepository
 import com.wafflestudio.waflog.global.auth.JwtTokenProvider
+import com.wafflestudio.waflog.global.auth.model.SignUpAttempt
 import com.wafflestudio.waflog.global.auth.model.VerificationToken
-import com.wafflestudio.waflog.global.oauth2.repository.OAuth2UserTokenRepository
+import com.wafflestudio.waflog.global.auth.repository.SignUpAttemptRepository
+import com.wafflestudio.waflog.global.auth.repository.VerificationTokenRepository
 import org.springframework.security.core.Authentication
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.stereotype.Component
@@ -18,9 +19,10 @@ import javax.servlet.http.HttpServletResponse
 @Component
 class OAuth2SuccessHandler(
     private val userRepository: UserRepository,
-    private val oAuth2UserTokenRepository: OAuth2UserTokenRepository,
-    private val objectMapper: ObjectMapper,
-    private val jwtTokenProvider: JwtTokenProvider
+    private val verificationTokenRepository: VerificationTokenRepository,
+    private val signUpAttemptRepository: SignUpAttemptRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val passwordEncoder: PasswordEncoder
 ) : AuthenticationSuccessHandler {
 
     override fun onAuthenticationSuccess(
@@ -35,41 +37,43 @@ class OAuth2SuccessHandler(
             throw ServletException()
 
         // register user if not exists
-        val existingUser = userRepository.findByEmail(email)
+        userRepository.findByEmail(email)?.run {
+            // generate verification token for JWT authentication
+            val token = generateOAuth2UserToken(email)
 
-        val user = existingUser ?: run {
-            userRepository.save(
-                User(
-                    email = email,
-                    userId = (oAuth2User.attributes["userId"] as String),
-                    name = (oAuth2User.attributes["name"] as String),
-                    image = oAuth2User.attributes["image"]?.let(Any::toString)
-                        ?: "https://wafflestudio.com/_next/image?url=%2Fimages%2Ficon_intro.svg&w=640&q=75",
-                    pageTitle = (oAuth2User.attributes["pageTitle"] as String)
-                )
+            // return redirect response
+            val jwt = jwtTokenProvider.generateToken(email)
+            response.addHeader("Location", "https://waflog-web.kro.kr/social?token=$jwt")
+            response.status = HttpServletResponse.SC_TEMPORARY_REDIRECT
+        } ?: run {
+            // generate JWT for register
+            val jwt = jwtTokenProvider.generateToken(email, signup = true)
+
+            // save image URL if exists
+            val image = oAuth2User.attributes["image"]?.let(Any::toString) ?: ""
+
+            signUpAttemptRepository.save(SignUpAttempt(email, image, jwt))
+
+            // return redirect response
+            response.addHeader(
+                "Location",
+                "https://waflog-web.kro.kr/register?email=$email&token=$jwt"
             )
+            response.status = HttpServletResponse.SC_TEMPORARY_REDIRECT
         }
-
-        // generate verification token for JWT authentication
-        val token = generateOAuth2UserToken(email)
-
-        // write JWT token to response
-        val jwt = jwtTokenProvider.generateToken(email)
-        response.addHeader("Location", "https://waflog-web.kro.kr/social?token=$jwt")
-        response.status = HttpServletResponse.SC_TEMPORARY_REDIRECT
     }
 
     private fun generateOAuth2UserToken(email: String): String {
         val token = UUID.randomUUID().toString()
 
-        val existingToken = oAuth2UserTokenRepository.findByEmail(email)
+        val existingToken = verificationTokenRepository.findByEmail(email)
 
         existingToken?.also { // reuse token if exists: unique OAuth2UserToken
-            it.token = token
-            oAuth2UserTokenRepository.save(it)
+            it.token = passwordEncoder.encode(token)
+            verificationTokenRepository.save(it)
         } ?: run {
-            val verificationToken = VerificationToken(email, token)
-            oAuth2UserTokenRepository.save(verificationToken)
+            val verificationToken = VerificationToken(email, passwordEncoder.encode(token))
+            verificationTokenRepository.save(verificationToken)
         }
 
         return token

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/oauth2/repository/OAuth2UserTokenRepository.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/oauth2/repository/OAuth2UserTokenRepository.kt
@@ -1,9 +1,0 @@
-package com.wafflestudio.waflog.global.oauth2.repository
-
-import com.wafflestudio.waflog.global.auth.model.VerificationToken
-import org.springframework.data.jpa.repository.JpaRepository
-
-interface OAuth2UserTokenRepository : JpaRepository<VerificationToken, Long?> {
-    fun findByToken(token: String?): VerificationToken?
-    fun findByEmail(email: String?): VerificationToken?
-}

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/oauth2/service/CustomAuth2UserService.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/oauth2/service/CustomAuth2UserService.kt
@@ -52,10 +52,7 @@ class CustomAuth2UserService : DefaultOAuth2UserService() {
         val email: String = mainEmailResponse["email"] as String
         val memberAttributes: HashMap<String, Any?> = hashMapOf(
             "email" to email,
-            "userId" to oauth2User.attributes["login"],
-            "name" to oauth2User.attributes["login"],
-            "image" to oauth2User.attributes["avatar_url"],
-            "pageTitle" to "${oauth2User.attributes["login"]}.log"
+            "image" to oauth2User.attributes["avatar_url"]
         )
 
         return DefaultOAuth2User(
@@ -83,13 +80,8 @@ class CustomAuth2UserService : DefaultOAuth2UserService() {
         TODO: saving imageResponse(Bytearray) in S3 and return url
          */
 
-        val emailId = (oauth2User.attributes["email"] as String).substringBefore("@")
-
         val memberAttributes: HashMap<String, Any?> = hashMapOf(
-            "email" to oauth2User.attributes["email"],
-            "userId" to emailId,
-            "name" to oauth2User.attributes["name"],
-            "pageTitle" to "$emailId.log"
+            "email" to oauth2User.attributes["email"]
         )
 
         return DefaultOAuth2User(
@@ -103,14 +95,9 @@ class CustomAuth2UserService : DefaultOAuth2UserService() {
 
     fun getGoogleUser(oauth2User: OAuth2User, userRequest: OAuth2UserRequest?): OAuth2User {
 
-        val emailId = (oauth2User.attributes["email"] as String).substringBefore("@")
-
         val memberAttributes: HashMap<String, Any?> = hashMapOf(
             "email" to oauth2User.attributes["email"],
-            "userId" to emailId,
-            "name" to oauth2User.attributes["name"],
-            "image" to oauth2User.attributes["picture"],
-            "pageTitle" to "$emailId.log"
+            "image" to oauth2User.attributes["picture"]
         )
 
         return DefaultOAuth2User(


### PR DESCRIPTION
## PR 타입
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
소셜 로그인과 회원가입을 별도의 페이지로 리다이렉트시킵니다.
소셜 로그인에서 사용하던 OAuth2UserToken 대신, 기존의 VeficiationToken을 사용하도록 변경했습니다.
순환 참조 문제를 해결하기 위해 PasswordEncoder를 별도의 config로 분리하였습니다.

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [ ] 코드의 이해에 필요한 주석을 작성했습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [ ] 기존 및 신규 단위 테스트를 통과했습니다.
- [ ] (필요한 경우) 문서를 적절하게 수정했습니다.
