### PR TITLE
fix: [#179] make POST /verify/logout permitAll

### DIFF
--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/SecurityConfig.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/global/config/SecurityConfig.kt
@@ -73,6 +73,7 @@ class SecurityConfig(
             ).permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/auth/verify").permitAll()
             .antMatchers(HttpMethod.POST, "/api/v1/auth/verify/login").permitAll()
+            .antMatchers(HttpMethod.POST, "/api/v1/auth/verify/logout").permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/post/recent", "/api/v1/post/trend").permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/post/{\\d+}", "/api/v1/post/search").permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/post/@**/**").permitAll()


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
verify logout API를 jwt token authentication 없이 access할 수 있도록 합니다.

Resolves #179

## 체크리스트
- [ ] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [ ] 코드의 이해에 필요한 주석을 작성했습니다.
- [ ] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [ ] 기존 및 신규 단위 테스트를 통과했습니다.
- [ ] (필요한 경우) 문서를 적절하게 수정했습니다.
