### PR TITLE
BUG: #214 modifying withdraw logic and refactoring method name

### DIFF
--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/repository/LikesRepository.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/repository/LikesRepository.kt
@@ -16,7 +16,7 @@ interface LikesRepository : JpaRepository<Likes, Long?> {
     @Transactional
     @Modifying
     @Query("DELETE FROM Likes l WHERE l.user.id = :userId")
-    fun deleteAllByUserId(@Param("userId") userId: Long)
+    fun deleteMappingByUserId(@Param("userId") userId: Long)
 
     @Transactional
     @Modifying
@@ -24,5 +24,5 @@ interface LikesRepository : JpaRepository<Likes, Long?> {
         "DELETE FROM Likes l WHERE l.likedPost.id in " +
             "(SELECT p.id FROM Post p WHERE (p.user.id = :userId))"
     )
-    fun deleteMappingByUserId(@Param("userId") userId: Long)
+    fun deleteMappingByUserIdOfPost(@Param("userId") userId: Long)
 }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/repository/ReadsRepository.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/repository/ReadsRepository.kt
@@ -29,5 +29,4 @@ interface ReadsRepository : JpaRepository<Reads, Long?> {
         "DELETE FROM Reads r WHERE r.user.id = :userId"
     )
     fun deleteMappingByUserId(@Param("userId") userId: Long)
-
 }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/repository/ReadsRepository.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/repository/ReadsRepository.kt
@@ -21,5 +21,13 @@ interface ReadsRepository : JpaRepository<Reads, Long?> {
         "DELETE FROM Reads r WHERE r.readPost.id in " +
             "(SELECT rp.id FROM Post rp WHERE (rp.user.id = :userId))"
     )
+    fun deleteMappingByUserIdOfPost(@Param("userId") userId: Long)
+
+    @Transactional
+    @Modifying
+    @Query(
+        "DELETE FROM Reads r WHERE r.user.id = :userId"
+    )
     fun deleteMappingByUserId(@Param("userId") userId: Long)
+
 }

--- a/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/service/UserService.kt
+++ b/waflog/src/main/kotlin/com/wafflestudio/waflog/domain/user/service/UserService.kt
@@ -273,19 +273,25 @@ class UserService(
 
         // delete user's post
         postTokenRepository.deleteAllMappingByUserId(user.id)
+
         likesRepository.deleteMappingByUserId(user.id)
+        likesRepository.deleteMappingByUserIdOfPost(user.id)
+
         readsRepository.deleteMappingByUserId(user.id)
+        readsRepository.deleteMappingByUserIdOfPost(user.id)
+
         commentRepository.deleteAllCommentMappingByUserId(user.id)
+        commentRepository.updateCommentWriterByNull(user.id) // update user's comment to null's comment
+
         postTagRepository.deleteMappingByUserId(user.id)
-        postRepository.deleteAllUserPosts(user.id)
         tagRepository.deleteUnusedTags()
+
+        postRepository.deleteAllUserPosts(user.id)
 
         // delete user's saves
         saveTokenRepository.deleteAllMappingByUserId(user.id)
         saveRepository.deleteAllUserSaves(user.id)
 
-        commentRepository.updateCommentWriterByNull(user.id) // update user's comment to null's comment
-        likesRepository.deleteAllByUserId(user.id) // delete all likes by user
         verificationTokenRepository.findByEmail(user.email)?.let {
             verificationTokenRepository.deleteById(it.id) // delete user token
         }


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [x] 기타 설정

## PR 설명
탈퇴시 엔티티가 삭제되지 않아서 참조 버그가 발생한 reads를 삭제,
메서드 이름 리팩토링
deleteMappingByUserId를 그 유저가 행한 엔티티(reads의 경우 그 유저가 읽은 reads, likes는 그 유저가 좋아요한 likes)
deleteMappingByUserIdOfPost를 그 유저가 작성한 게시글에 달린 reads와 likes를 삭제하는 메서드로 이름을 통일하고 보기 쉽게 순서 변경

Resolves #214 

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [ ] 코드의 이해에 필요한 주석을 작성했습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [x] 기존 및 신규 단위 테스트를 통과했습니다.
- [ ] (필요한 경우) 문서를 적절하게 수정했습니다.
